### PR TITLE
Extract a palette from the first input image: `--palette "sample"`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/disintegration/imaging v1.6.2
 	github.com/makeworld-the-better-one/dither/v2 v2.3.0
+	github.com/mccutchen/palettor v1.0.0 // indirect
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/image v0.0.0-20210220032944-ac19c3e999fb
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,9 @@ github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1
 github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
 github.com/makeworld-the-better-one/dither/v2 v2.3.0 h1:s9wgm88KFZSzvZh9gL79tPayp5sDUGIku/1aJewxlB4=
 github.com/makeworld-the-better-one/dither/v2 v2.3.0/go.mod h1:VBtN8DXO7SNtyGmLiGA7IsFeKrBkQPze1/iAeM95arc=
+github.com/mccutchen/palettor v1.0.0 h1:YRNAzEZlRBnu8qP/9siuNTJiAj7VhL0dEQ1AQmu9jew=
+github.com/mccutchen/palettor v1.0.0/go.mod h1:5ZFq9YwI0o5zRpmAuEsm+0B7divaVds1dvTAznEnd6g=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=

--- a/main.go
+++ b/main.go
@@ -36,6 +36,10 @@ func main() {
 				Aliases:  []string{"p"},
 				Required: true,
 			},
+			&cli.IntFlag{
+				Name:    "paletteSize",
+				Aliases: []string{"k"},
+			},
 			&cli.BoolFlag{
 				Name:    "grayscale",
 				Aliases: []string{"g"},

--- a/subcommand_helpers.go
+++ b/subcommand_helpers.go
@@ -405,7 +405,7 @@ func processImages(d *dither.Ditherer, c *cli.Context) error {
 		} else if loopCount != 0 {
 			// The CLI flag is equal to the number of times looped
 			// But for gif.GIF.LoopCount, "the animation is looped LoopCount+1 times."
-			loopCount -= 1
+			loopCount--
 		}
 		animGIF = gif.GIF{
 			Image:     frames,

--- a/subcommand_helpers.go
+++ b/subcommand_helpers.go
@@ -148,9 +148,11 @@ func extractInputPalette(flag string, c *cli.Context) ([]color.Color, error) {
 	// https://github.com/mccutchen/palettor/blob/3eaed180/cmd/palettor/palettor.go#L57
 	thumbnail := imaging.Resize(img, 200, 200, imaging.NearestNeighbor)
 
-	// TODO: make these settings configurable, particularly the number of colors
-	// in the palette. That means threading the argument through the CLI.
-	palette, err := palettor.Extract(5, 500, thumbnail)
+	k := c.Int("paletteSize")
+	if k == 0 {
+		k = 5
+	}
+	palette, err := palettor.Extract(k, 500, thumbnail)
 	if err != nil {
 		return nil, fmt.Errorf("error extracting image palette: %w", err)
 	}

--- a/subcommand_helpers.go
+++ b/subcommand_helpers.go
@@ -23,6 +23,10 @@ import (
 	"golang.org/x/image/colornames"
 )
 
+const (
+	defaultExtractedPaletteSize = 5
+)
+
 // parsePercentArg takes a string like "0.5" or "50%" and will return a float
 // like 50 or 0.5, depending on the second argument. An empty string returns 0.
 //
@@ -149,8 +153,9 @@ func extractInputPalette(flag string, c *cli.Context) ([]color.Color, error) {
 	thumbnail := imaging.Resize(img, 200, 200, imaging.NearestNeighbor)
 
 	k := c.Int("paletteSize")
-	if k == 0 {
-		k = 5
+	if k < 2 {
+		k = defaultExtractedPaletteSize
+		log.Printf("Must have at least two-color palette; defaulting to %v", k)
 	}
 	palette, err := palettor.Extract(k, 500, thumbnail)
 	if err != nil {

--- a/subcommands.go
+++ b/subcommands.go
@@ -71,39 +71,6 @@ func preProcess(c *cli.Context) error {
 	runtime.GOMAXPROCS(int(c.Uint("threads")))
 
 	var err error
-	palette, err = parseColors("palette", c)
-	if err != nil {
-		return err
-	}
-	if len(palette) < 2 {
-		return errors.New("the palette must have at least two colors")
-	}
-
-	if c.String("recolor") != "" {
-		recolorPalette, err = parseColors("recolor", c)
-		if err != nil {
-			return err
-		}
-		if len(recolorPalette) != len(palette) {
-			return errors.New("recolor palette must have the same number of colors as the initial palette")
-		}
-	}
-
-	// Check if palette is grayscale and make image grayscale
-	// Or if the user forces it
-
-	grayscale = true
-	if !c.Bool("grayscale") {
-		// Grayscale isn't specified by the user
-		// So check to see if palette is grayscale
-		for _, c := range palette {
-			r, g, b, _ := c.RGBA()
-			if r != g || g != b {
-				grayscale = false
-				break
-			}
-		}
-	}
 
 	saturation, err = parsePercentArg(c.String("saturation"), false)
 	if err != nil {
@@ -135,6 +102,40 @@ func preProcess(c *cli.Context) error {
 			inputImages = append(inputImages, paths...)
 		} else {
 			inputImages = append(inputImages, path)
+		}
+	}
+
+	palette, err = parseColors("palette", c)
+	if err != nil {
+		return err
+	}
+	if len(palette) < 2 {
+		return errors.New("the palette must have at least two colors")
+	}
+
+	if c.String("recolor") != "" {
+		recolorPalette, err = parseColors("recolor", c)
+		if err != nil {
+			return err
+		}
+		if len(recolorPalette) != len(palette) {
+			return errors.New("recolor palette must have the same number of colors as the initial palette")
+		}
+	}
+
+	// Check if palette is grayscale and make image grayscale
+	// Or if the user forces it
+
+	grayscale = true
+	if !c.Bool("grayscale") {
+		// Grayscale isn't specified by the user
+		// So check to see if palette is grayscale
+		for _, c := range palette {
+			r, g, b, _ := c.RGBA()
+			if r != g || g != b {
+				grayscale = false
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
## Changes

Adds a dependency on https://github.com/mccutchen/palettor.

When passed `--palette "sample"`, use `palettor` to extract a $k$-palette from the 0th input image.

Reorders `preProcess`: parse the `inputImages` before constructing the palette, since palette construction can depend on loading the image.

### Things to check

+ Docs need updating.
  + Document the `--palette "sample"` behavior.
  + Document the parameterized palette size $k$.
+ Does this behave reasonably for multiple input images?
+ Does this behave reasonably when the image comes from stdin?

### Notes

I wouldn't mind an interface with some more niceties, like https://ditherit.com/.

Sometimes `palettor` seems to produce bad palette results; it's comfortable picking colors that are really close to one another instead of selecting for contrast.

Given this source image:

![download](https://user-images.githubusercontent.com/4955943/225454570-b99a26b2-9c6c-4f6a-be96-5f6b5359c973.jpg)

Consider:

![out](https://user-images.githubusercontent.com/4955943/225451947-64a15c5f-309b-4229-a978-2a73c84a5386.png)

Compare to a ditherit output with their default palette:

![download-2](https://user-images.githubusercontent.com/4955943/225452376-d16ab6bd-a8cf-46d4-afeb-a83b0b5d44b4.jpg)

That's probably a palette generated by https://github.com/leeoniya/RgbQuant.js. Perhaps I can tweak the palettor strategy to prefer contrast.

I can look into using something like https://pkg.go.dev/github.com/RobCherry/vibrant, but that offers somewhat less flexibility than KNN –– namely, you don't get to set $k$.

## Testing


```console
$ go run . -i ~/Desktop/Raja_Ravi_Varma,_Lord_Garuda.jpg -o out.png --palette "sample" -k 2 edm --serpentine FloydSteinberg
```